### PR TITLE
Avoid mutating jumpstateDefaults

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,9 @@ export default function (...args) {
     }
   }
 
-  const config = Object.assign(jumpstateDefaults, {
+  const config = Object.assign({
     name: shortID()
-  }, userConfig)
+  }, jumpstateDefaults, userConfig)
 
   // Checks
   if (typeof config.name === 'string' && !config.name.length) {


### PR DESCRIPTION
The config Object.assign was adding properties into the jumpstateDefaults object. 
By switching the assign order, mutation is avoided.