### PR TITLE
Remove multiPayload and all of _jumpstate as it's unnecessary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,8 +38,7 @@ export default function (...args) {
       return currentState
     }
     // Compute the next state
-    const payload = action._jumpstate.multiPayload ? action.payload : [action.payload]
-    const nextState = prefixedActions[action.type](state, ...payload)
+    const nextState = prefixedActions[action.type](state, ...action.payload)
     currentState = config.autoAssign ? Object.assign({}, state, nextState) : nextState
     // If autoAssign is on, extend the state to avoid mutation
     return currentState
@@ -54,15 +53,9 @@ export default function (...args) {
 
     // Create a method at reducer[actionName] to call our action
     reducerWithActions[actionName] = (...payload) => {
-      const multiPayload = payload.length > 1
       const action = {
-        _jumpstate: {
-          stateName: config.name,
-          actionName: actionName,
-          multiPayload: multiPayload
-        },
         type: prefixedActionName,
-        payload: multiPayload ? payload : payload[0]
+        payload
       }
 
       if (config.actionCreator) {


### PR DESCRIPTION
I don't see `_jumpstate.stateName` or `.actionName` used anywhere (unless they're for debugging purposes), so I removed them. 

But `multiPayload` seemed completely unnecessary because `...payload` is always an array, whether it contains one argument or multiple. So there is no need to extract the single item, just to re-wrap it later using the `multiPayload` flag.