### PR TITLE
Move Babel config to .babelrc for React Native

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    "es2015",
+    "stage-2",
+    "react"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -52,13 +52,6 @@
       "jumpstate.js"
     ]
   },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2",
-      "react"
-    ]
-  },
   "bugs": {
     "url": "https://github.com/jumpsuit/jumpstate/issues"
   },


### PR DESCRIPTION
When the Babel config was in
package.json, React Native didn't work: it
through some error about incorrect
Babel config.

