### PR TITLE
Fix State reducer to use state hydration from redux

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -20,14 +20,16 @@ export default function (...args) {
 
   let currentState = initialState
 
-  const reducerWithActions = (state = initialState, action = {}) => {
+  const reducerWithActions = (state, action = {}) => {
     if (namedActions[action.type]) {
       // For namespaced actions, look for the prefixedAction
       const nextState = namedActions[action.type](state, action.payload)
       // Extend the state to avoid mutation
-      currentState = Object.assign({}, state, nextState)
+      return Object.assign({}, state, nextState)
     }
-    return currentState
+    // If redux already has a stored previous state, use that
+    // Otherwise, fallback to the user-provided state
+    return state || currentState
   }
 
   // Loop through the actions and proxy them to do awesome stuff

--- a/src/state.js
+++ b/src/state.js
@@ -17,17 +17,26 @@ export default function (...args) {
   delete actions.initial
 
   const namedActions = {}
+  
+  let currentState
 
   const reducerWithActions = (state, action = {}) => {
     if (namedActions[action.type]) {
       // For namespaced actions, look for the prefixedAction
       const nextState = namedActions[action.type](state, action.payload)
       // Extend the state to avoid mutation
-      return Object.assign({}, state, nextState)
+      currentState = Object.assign({}, state, nextState)
     }
-    // If the store already has a stored previous state, use that
-    // Otherwise, fallback to the user-provided initial state
-    return state || initialState
+    else {
+      // If the store already has a stored previous state, use that
+      // Otherwise, fallback to the user-provided initial state
+      currentState = state || initialState
+    }
+    return currentState
+  }
+  
+  reducerWithActions.getState = () => {
+    return currentState
   }
 
   // Loop through the actions and proxy them to do awesome stuff

--- a/src/state.js
+++ b/src/state.js
@@ -25,8 +25,8 @@ export default function (...args) {
       // Extend the state to avoid mutation
       return Object.assign({}, state, nextState)
     }
-    // If redux already has a stored previous state, use that
-    // Otherwise, fallback to the user-provided state
+    // If the store already has a stored previous state, use that
+    // Otherwise, fallback to the user-provided initial state
     return state || initialState
   }
 

--- a/src/state.js
+++ b/src/state.js
@@ -18,8 +18,6 @@ export default function (...args) {
 
   const namedActions = {}
 
-  let currentState = initialState
-
   const reducerWithActions = (state, action = {}) => {
     if (namedActions[action.type]) {
       // For namespaced actions, look for the prefixedAction
@@ -29,7 +27,7 @@ export default function (...args) {
     }
     // If redux already has a stored previous state, use that
     // Otherwise, fallback to the user-provided state
-    return state || currentState
+    return state || initialState
   }
 
   // Loop through the actions and proxy them to do awesome stuff


### PR DESCRIPTION
Currently, when you call `createStore()` with an `initialState` argument, the `initial` object of each State overides the `initialState` passed down from redux. Not sure if this is intentional, but this means that you cannot hydrate the state tree at boot (i.e from localstorage, isomorphic rendering etc).

Loving your work though guys! This stuff rocks.