### PR TITLE
Fixing some linter errors

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -2,7 +2,7 @@ import { EffectRegistry } from './effect'
 import { HookRegistry } from './hook'
 
 const warningFn = () => {
-  console.warn(`It looks like you\'re trying to use Jumpstate without the middleware! For Jumpstate to work, you need to run CreateJumpstateMiddleware() and apply it as middleware to your Redux Store.`)
+  console.warn(`It looks like you're trying to use Jumpstate without the middleware! For Jumpstate to work, you need to run CreateJumpstateMiddleware() and apply it as middleware to your Redux Store.`)
 }
 let resolvedDispatch = warningFn
 let resolvedGetState = warningFn

--- a/src/state.js
+++ b/src/state.js
@@ -17,7 +17,7 @@ export default function (...args) {
   delete actions.initial
 
   const namedActions = {}
-  
+
   let currentState
 
   const reducerWithActions = (state, action = {}) => {
@@ -26,15 +26,14 @@ export default function (...args) {
       const nextState = namedActions[action.type](state, action.payload)
       // Extend the state to avoid mutation
       currentState = Object.assign({}, state, nextState)
-    }
-    else {
+    } else {
       // If the store already has a stored previous state, use that
       // Otherwise, fallback to the user-provided initial state
       currentState = state || initialState
     }
     return currentState
   }
-  
+
   reducerWithActions.getState = () => {
     return currentState
   }

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -1,5 +1,7 @@
 import Actions, { addAction, removeAction } from '../src/actions'
 
+/* global test, expect */
+
 test('Imports Actions', () => {
   expect(Actions).toEqual({})
 })

--- a/test/effect.test.js
+++ b/test/effect.test.js
@@ -1,5 +1,7 @@
 import Effect from '../src/effect'
 
+/* global test, expect */
+
 test('Import Effect', () => {
   expect(Effect).toBeDefined()
 })

--- a/test/hook.test.js
+++ b/test/hook.test.js
@@ -1,5 +1,7 @@
 import Hook from '../src/hook'
 
+/* global test, expect */
+
 test('Import Hook', () => {
   expect(Hook).toBeDefined()
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,7 @@
 import * as All from '../src/index'
 
+/* global test, expect */
+
 test('Import Index', () => {
   expect(All).toBeDefined()
 })

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,5 +1,7 @@
 import Middleware from '../src/middleware'
 
+/* global test, expect */
+
 test('Import Middleware', () => {
   expect(Middleware).toBeDefined()
 })

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1,5 +1,7 @@
 import State from '../src/state'
 
+/* global test, expect */
+
 test('Import State', () => {
   expect(State).toBeDefined()
 })


### PR DESCRIPTION
I want to try to write some tests and I tough it would be a good idea to first resolve the linter errors.

Before it was: 

```
/home/adilson/Projects/jumpstate/examples/counter.js
  64:1   error  'React' is not defined                      no-undef
  94:7   error  'store' is assigned a value but never used  no-unused-vars
  94:15  error  'createStore' is not defined                no-undef
  95:3   error  'combineReducers' is not defined            no-undef
  97:3   error  'applyMiddlware' is not defined             no-undef

/home/adilson/Projects/jumpstate/src/middleware.js
  5:33  error  Unnecessary escape character: \'  no-useless-escape

/home/adilson/Projects/jumpstate/src/state.js
  20:1   error  Trailing spaces not allowed                                                   no-trailing-spaces
  30:10  error  Closing curly brace does not appear on the same line as the subsequent block  brace-style
  37:1   error  Trailing spaces not allowed                                                   no-trailing-spaces

/home/adilson/Projects/jumpstate/test/actions.test.js
   3:1  error  'test' is not defined    no-undef
   4:3  error  'expect' is not defined  no-undef
   7:1  error  'test' is not defined    no-undef
  10:3  error  'expect' is not defined  no-undef
  12:3  error  'expect' is not defined  no-undef

/home/adilson/Projects/jumpstate/test/effect.test.js
  3:1  error  'test' is not defined    no-undef
  4:3  error  'expect' is not defined  no-undef

/home/adilson/Projects/jumpstate/test/hook.test.js
  3:1  error  'test' is not defined    no-undef
  4:3  error  'expect' is not defined  no-undef

/home/adilson/Projects/jumpstate/test/index.test.js
  3:1  error  'test' is not defined    no-undef
  4:3  error  'expect' is not defined  no-undef

/home/adilson/Projects/jumpstate/test/middleware.test.js
  3:1  error  'test' is not defined    no-undef
  4:3  error  'expect' is not defined  no-undef

/home/adilson/Projects/jumpstate/test/state.test.js
  3:1  error  'test' is not defined    no-undef
  4:3  error  'expect' is not defined  no-undef
```
Now it is:

```
/home/adilson/Projects/jumpstate/examples/counter.js
  64:1   error  'React' is not defined                      no-undef
  94:7   error  'store' is assigned a value but never used  no-unused-vars
  94:15  error  'createStore' is not defined                no-undef
  95:3   error  'combineReducers' is not defined            no-undef
  97:3   error  'applyMiddlware' is not defined             no-undef
```

I haven't fixed `exemples/counter.js` because it is a special case. I don't know if I should make it work or if I should ignore this file altogether... Ideas? 