### PR TITLE
Make unit tests run despite linting errors. closes #14

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "test:lint": "standard --verbose | snazzy",
     "test:unit": "jest --coverage",
-    "test": "npm-run-all test:*",
+    "test": "npm-run-all -c test:*",
     "build:node": "rm -rf lib && babel src -d lib --no-comments",
     "build:umd": "rm -rf jumpstate.js && browserify lib/index.js -s jumpstate -tg uglifyify -o jumpstate.js",
     "watch": "npm run build:node -- -w -s",


### PR DESCRIPTION
Now unit tests are run whenever there are lint erros or not.