### PR TITLE
Actions addAction error handling

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3,6 +3,10 @@ const Actions = {}
 export default Actions
 
 export function addAction (actionName, action) {
+  // Make sure the name is unique
+  if (Actions[actionName]) {
+    throw new Error(`An action called "${actionName}" already exists! Please pick another name!`)
+  }
   Actions[actionName] = payload => action(payload)
 }
 

--- a/src/effect.js
+++ b/src/effect.js
@@ -1,5 +1,5 @@
 import { getState, dispatch } from './middleware'
-import Actions, { addAction, removeAction } from './actions'
+import { addAction, removeAction } from './actions'
 
 export const EffectRegistry = {}
 const effectPromises = {}

--- a/src/effect.js
+++ b/src/effect.js
@@ -10,11 +10,6 @@ export default function (name, callback) {
     throw new Error('Named effects require a valid string as the name eg. Effect("myAction", () => {...})')
   }
 
-  // Make sure the name is unique
-  if (Actions[name]) {
-    throw new Error(`An action called "${name}" already exists! Please pick another name for this effect!`)
-  }
-
   const callbackWrapper = (action) => {
     const { payload, ts } = action
     Promise.resolve(callback(payload, getState, dispatch))

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -1,6 +1,10 @@
 import Actions, { addAction, removeAction } from '../src/actions'
 
-/* global test, expect */
+/* global test, expect, beforeEach, jest */
+
+beforeEach(() => {
+  jest.resetModules()
+})
 
 test('Imports Actions', () => {
   expect(Actions).toEqual({})
@@ -12,4 +16,11 @@ test('Add/Remove Action', () => {
   expect(Actions.increment).toBeDefined()
   removeAction('increment')
   expect(Actions.increment).toBeUndefined()
+})
+
+test('Add action should prevent dups', () => {
+  const cb = () => {}
+  addAction('increment', cb)
+  expect(Actions.increment).toBeDefined()
+  expect(() => { addAction('increment', cb) }).toThrow()
 })

--- a/test/effect.test.js
+++ b/test/effect.test.js
@@ -1,7 +1,17 @@
 import Effect from '../src/effect'
 
-/* global test, expect */
+/* global test, expect, beforeEach, jest */
+
+beforeEach(() => {
+  jest.resetModules()
+})
 
 test('Import Effect', () => {
   expect(Effect).toBeDefined()
+})
+
+test('Effect should throw error when action namespace is already taken', () => {
+  const cb = () => {}
+  expect(() => { Effect('someEffect', cb) }).not.toThrow()
+  expect(() => { Effect('someEffect', cb) }).toThrow()
 })


### PR DESCRIPTION
Now `Action.addAction` will prevent global overwrite. Removed the check from `effect.js` as it will be made at the time it tries to add the action, but I added a test to effect.test.js to prevent future regression. closes #13 
