### PR TITLE
fix return for hooks to allow cancel

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -17,5 +17,5 @@ export default function (callback) {
     HookRegistry.splice(HookRegistry.indexOf(callbackWrapper), 1)
   }
 
-  return callbackWrapper
+  return returnMethod
 }


### PR DESCRIPTION
There is a problem in hooks which prevents calling `myHook.cancel()`.

This should resolve the problem.