### PR TITLE
Fix State.js test  expect().toThrow() 

### DIFF
--- a/test/state.test.js
+++ b/test/state.test.js
@@ -156,40 +156,50 @@ describe('Sandboxed State', () => {
     const Jumpstate = require('../src/index')
     const State = Jumpstate.State
 
-    expect(State('sandboxReducer', {
-      initial: { value: 0 },
-      setValue (state, payload) {
-        return { value: payload }
-      }
-    })).not.toThrow()
+    expect(() => {
+      State('sandboxReducer', {
+        initial: { value: 0 },
+        setValue (state, payload) {
+          return { value: payload }
+        }
+      })
+    }).not.toThrow()
 
-    expect(State('', {
-      initial: { value: 0 },
-      setValue (state, payload) {
-        return { value: payload }
-      }
-    })).toThrow()
+    expect(() => {
+      State('', {
+        initial: { value: 0 },
+        setValue (state, payload) {
+          return { value: payload }
+        }
+      })
+    }).toThrow()
 
-    expect(State(() => { return 'sandboxedReducer' }, {
-      initial: { value: 0 },
-      setValue (state, payload) {
-        return { value: payload }
-      }
-    })).toThrow()
+    expect(() => {
+      State(() => { return 'sandboxedReducer' }, {
+        initial: { value: 0 },
+        setValue (state, payload) {
+          return { value: payload }
+        }
+      })
+    }).toThrow()
 
-    expect(State(null, {
-      initial: { value: 0 },
-      setValue (state, payload) {
-        return { value: payload }
-      }
-    })).toThrow()
+    expect(() => {
+      State(null, {
+        initial: { value: 0 },
+        setValue (state, payload) {
+          return { value: payload }
+        }
+      })
+    }).toThrow()
 
-    expect(State(9, {
-      initial: { value: 0 },
-      setValue (state, payload) {
-        return { value: payload }
-      }
-    })).toThrow()
+    expect(() => {
+      State(9, {
+        initial: { value: 0 },
+        setValue (state, payload) {
+          return { value: payload }
+        }
+      })
+    }).toThrow()
   })
 
   it('wont setup a global action creator', () => {


### PR DESCRIPTION
To expect().toThrow() properly works it needs to receive the statement wrapped in a function otherwise I'm just passing an error instead of a function that will throw an error.

This test still fails, but can now correctly assert the correction.