### PR TITLE
fix validation on sandboxed state name

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -8,7 +8,7 @@ export default function (...args) {
   const actions = isSandboxed ? args[1] : args[0]
 
   // Checks
-  if (sandboxName && typeof sandboxName === 'string' && !sandboxName.length) {
+  if (isSandboxed && (typeof sandboxName !== 'string' || !sandboxName.length)) {
     throw new Error('Sandboxed states names must be a valid string')
   }
 


### PR DESCRIPTION
Will make the remaining failing test pass.

Code coverage on state.js will now be:

File           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------|----------|----------|----------|----------|----------------|
 state.js      |      100 |    95.24 |      100 |      100 |                |
---------------|----------|----------|----------|----------|----------------|
