### PR TITLE
Truncate the effectPromises array on promise completion

### DIFF
--- a/src/effect.js
+++ b/src/effect.js
@@ -17,6 +17,9 @@ export default function (name, callback) {
       Promise.resolve(response)
         .then(effectPromises[_jumpstateTimestamp].resolve)
         .catch(effectPromises[_jumpstateTimestamp].reject)
+        .then(() => {
+          delete effectPromises[_jumpstateTimestamp]
+        })
     }
   }
 


### PR DESCRIPTION
# Description

As a long-lived application continues to run, the `effectPromises` array never truncates as the promises completes. It gets larger and larger.

This simple change removes the completed promises. Full test suite run.

```
> jest --coverage

 PASS  test/state.test.js
 PASS  test/actions.test.js
 PASS  test/effect.test.js
 PASS  test/middleware.test.js
 PASS  test/index.test.js


  1 Truncate the effectPromises array on promise completion
 PASS  test/hook.test.js
---------------|----------|----------|----------|----------|----------------|
File           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------|----------|----------|----------|----------|----------------|
All files      |     74.8 |    81.63 |    53.13 |    76.47 |                |
 actions.js    |    91.43 |       90 |    71.43 |    96.88 |              8 |
 effect.js     |    40.74 |       20 |    14.29 |    40.74 |... 42,43,52,53 |
 hook.js       |    11.11 |      100 |        0 |    11.11 |... 13,16,17,20 |
 index.js      |      100 |      100 |      100 |      100 |                |
 middleware.js |       80 |       50 |     62.5 |    84.21 |        5,14,28 |
 state.js      |      100 |       95 |      100 |      100 |                |
---------------|----------|----------|----------|----------|----------------|

Test Suites: 6 passed, 6 total
Tests:       20 passed, 20 total
Snapshots:   0 total
Time:        3.882s
Ran all test suites.
```
- [ ] @tannerlinsley 
