### PR TITLE
use latest stateutils for every store

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -16,11 +16,8 @@ export let getState = (...args) => {
 
 export default function createMiddleware (options) {
   return (stateUtils) => {
-    // If we haven't lifted the stores dispatcher yet, do it just this once
-    if (resolvedDispatch === warningFn) {
-      resolvedDispatch = stateUtils.dispatch
-      resolvedGetState = stateUtils.getState
-    }
+    resolvedDispatch = stateUtils.dispatch
+    resolvedGetState = stateUtils.getState
     return (next) => {
       return action => {
         const result = next(action)

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -29,6 +29,10 @@ describe('CreateJumpstateMiddleware', () => {
 
     Reducer.setValue(1)
 
+    let state = Store.getState()
+
+    expect(state.value).toEqual(1)
+
     Store = Redux.createStore(
       Reducer,
       Redux.applyMiddleware(
@@ -38,7 +42,7 @@ describe('CreateJumpstateMiddleware', () => {
 
     Reducer.setValue(2)
 
-    const state = Store.getState()
+    state = Store.getState()
 
     expect(state.value).toEqual(2)
   })

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,7 +1,45 @@
 import Middleware from '../src/middleware'
 
-/* global test, expect */
+/* global test, expect, it,describe */
 
 test('Import Middleware', () => {
   expect(Middleware).toBeDefined()
+})
+
+describe('CreateJumpstateMiddleware', () => {
+  it('should not preserve storeUtils across stores', () => {
+    const Jumpstate = require('../src/index')
+    const State = Jumpstate.State
+    const CreateJumpstateMiddleware = Jumpstate.CreateJumpstateMiddleware
+    const Redux = require('redux')
+
+    const Reducer = State({
+      initial: { value: 0 },
+      setValue (state, payload) {
+        return { value: payload }
+      }
+    })
+
+    let Store = Redux.createStore(
+      Reducer,
+      Redux.applyMiddleware(
+        CreateJumpstateMiddleware()
+      )
+    )
+
+    Reducer.setValue(1)
+
+    Store = Redux.createStore(
+      Reducer,
+      Redux.applyMiddleware(
+        CreateJumpstateMiddleware()
+      )
+    )
+
+    Reducer.setValue(2)
+
+    const state = Store.getState()
+
+    expect(state.value).toEqual(2)
+  })
 })


### PR DESCRIPTION
I found this bug while writing tests for my Jumpstate reducers. We use the es `import`/`export` syntax in tests which makes jest's `resetModules()` useless for imported modules, leading to the store's `getState` function being broken (run tests on https://github.com/e-r-w/jumpstate/commit/6919d3f4b588ef0515827657508234fe77c45862) during tests where we create multiple stores. Not sure why this fixes the problem though? 

I've changed our tests to use the `require()` syntax w/`jest.resetModules()` but in the meantime I'm not entirely sure what other side effects this may also have (or maybe someone might need to create multiple stores in an application and can't?)