### PR TITLE
Tightly triggered Effects need unique IDs to all resolve

### DIFF
--- a/src/effect.js
+++ b/src/effect.js
@@ -3,6 +3,10 @@ import { addEffect, removeAction } from './actions'
 
 export const EffectRegistry = {}
 const effectPromises = {}
+const guidv4 = () => {
+  function s4 () { return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1) }
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4()
+}
 
 export default function (name, callback) {
   // Make sure the action name is a valid string
@@ -37,7 +41,7 @@ export default function (name, callback) {
   }
 
   const eventDispatcher = (payload) => {
-    const _jumpstateTimestamp = Date.now()
+    const _jumpstateTimestamp = guidv4()
     return new Promise((resolve, reject) => {
       effectPromises[_jumpstateTimestamp] = { resolve, reject }
       dispatch(actionCreator(payload, { _jumpstateTimestamp }))

--- a/test/effect.test.js
+++ b/test/effect.test.js
@@ -15,3 +15,33 @@ test('Effect should throw error when action namespace is already taken', () => {
   expect(() => { Effect('someEffect', cb) }).not.toThrow()
   expect(() => { Effect('someEffect', cb) }).toThrow()
 })
+
+test('Tightly looped effects should all resolve', () => {
+  const Jumpstate = require('../src/index')
+  const State = Jumpstate.State
+  const EffectR = Jumpstate.Effect
+  const CreateJumpstateMiddleware = Jumpstate.CreateJumpstateMiddleware
+  const Redux = require('redux')
+
+  const Reducer = State({
+    initial: { value: 0 },
+    setValue (state, payload) {
+      return { value: payload }
+    }
+  })
+
+  Redux.createStore(
+    Reducer,
+    Redux.applyMiddleware(
+      CreateJumpstateMiddleware()
+    )
+  )
+
+  const cb = () => { return Promise.resolve(true) }
+  const testEffect = EffectR('tightEffect', cb)
+  const promises = []
+  for (let i = 0; i < 100; i++) { promises.push(testEffect()) }
+  // A throw means the test fails.
+  // If a promise does not resolve, the test will time out and fail.
+  return Promise.all(promises).then(results => expect(results.length).toEqual(100))
+})


### PR DESCRIPTION
# Description

Let's say you have two effects: 

`Effect('effect1', () => { return Actions.effect2() })`
`Effect('effect2', () => { return Promise.resolve(true) })`

And you call them in this manner:

```
Actions.effect1();
```

Because the two actions are created in a tight loop, the unique id created to keep track of the effects, being a Date.now(), was not unique - this is sub-millisecond execution. The result is that `effect1` does not resolve.

This commit does the following:
* Changes the unique tag to a v4 GUID
* Adds a test for this scenario

@tannerlinsley I would like your feedback on the test - if you have a different idea for how to instantiate the Redux store so that the test can execute.